### PR TITLE
remove reference to remote-debugging-port in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -34,7 +34,7 @@ alternative to [RSelenium](https://github.com/ropensci/RSelenium).
 
 ## Installation
 
-``` r
+``` {r eval = FALSE}
 # Install selenider from CRAN
 install.packages("selenium")
 
@@ -62,7 +62,7 @@ is provided by selenium:
 library(selenium)
 ```
 
-```r
+```{r eval = FALSE}
 server <- selenium_server()
 ```
 
@@ -73,7 +73,7 @@ will be deleted when the session is closed. If you want the server to persist,
 meaning that you don't have to re-download the server each time, you can use
 the `temp` argument:
 
-```r
+``` {r eval = FALSE}
 server <- selenium_server(temp = FALSE)
 ```
 
@@ -102,7 +102,7 @@ The Selenium server won't be ready to be used immediately. If you used
 `selenium_server()` to create your server, you can pass it into
 `wait_for_server()`:
 
-``` r
+``` {r eval = FALSE}
 wait_for_server(server)
 ```
 
@@ -111,7 +111,7 @@ You can also use `server$read_output()` and `server$read_error()`
 If you used a different method to create your server, use
 `wait_for_selenium_available()` instead.
 
-```r
+``` {r eval = FALSE}
 wait_for_selenium_available()
 ```
 
@@ -122,7 +122,7 @@ article for more information.
 ## Starting the client
 
 Client sessions can be started using `SeleniumSession$new()`
-```r
+``` {r eval = FALSE}
 session <- SeleniumSession$new()
 ```
 
@@ -131,22 +131,6 @@ a different browser if you like.
 
 ```{r session}
 session <- SeleniumSession$new(browser = "chrome")
-```
-
-Here, we use the `capabilities` argument to specify options for the browser.
-Here, the `remote-debugging-port` argument to Chrome is used to make sure the port
-that the browser uses does not conflict with any others (and may be
-necessary if Chrome is not working by default).
-
-``` {r eval = FALSE}
-session <- SeleniumSession$new(
-  browser = "chrome",
-  capabilities = list(
-    `goog:chromeOptions` = list(
-      args = list("remote-debugging-port=9222")
-    )
-  )
-)
 ```
 
 ## Usage
@@ -172,7 +156,7 @@ session$
 
 session$close()
 ```
-```r
+``` {r eval = FALSE}
 server$kill()
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,22 +127,6 @@ argument to specify a different browser if you like.
 session <- SeleniumSession$new(browser = "chrome")
 ```
 
-Here, we use the `capabilities` argument to specify options for the
-browser. Here, the `remote-debugging-port` argument to Chrome is used to
-make sure the port that the browser uses does not conflict with any
-others (and may be necessary if Chrome is not working by default).
-
-``` r
-session <- SeleniumSession$new(
-  browser = "chrome",
-  capabilities = list(
-    `goog:chromeOptions` = list(
-      args = list("remote-debugging-port=9222")
-    )
-  )
-)
-```
-
 ## Usage
 
 Once the session has been successfully started, you can use the session

--- a/tests/testthat/helper-session.R
+++ b/tests/testthat/helper-session.R
@@ -6,22 +6,11 @@ test_session <- function(verbose = FALSE) {
   port <- as.integer(Sys.getenv("SELENIUM_PORT", 4444L))
   host <- Sys.getenv("SELENIUM_HOST", "localhost")
 
-  opts <- if (browser == "chrome") {
-    list(`goog:chromeOptions` = list(
-      args = list(
-        "remote-debugging-port=9222"
-      )
-    ))
-  } else {
-    NULL
-  }
-
   session <- try(SeleniumSession$new(
     browser = browser,
     port = port,
     host = host,
     verbose = verbose,
-    capabilities = opts
   ))
 
   if (inherits(session, "try-error")) {

--- a/vignettes/articles/debugging.Rmd
+++ b/vignettes/articles/debugging.Rmd
@@ -28,7 +28,7 @@ the logs from the server. If you ran the `java -jar ...` command manually, then
 you should be able to see the logs, but if you used `selenium_server()`, then
 you can use the `read_output()` and `read_error()` methods to read the logs.
 
-```r
+```{r eval = FALSE}
 server <- selenium_server()
 server$read_output()
 server$read_error()
@@ -67,7 +67,8 @@ at the server logs. You should see a line like:
 The URL at the end of this message can be used to extract an IP address and a port number, which
 can then be passed into the `host` and `port` arguments. For example, if the URL was:
 `http://172.17.0.1/4444`, you would run:
-```r
+
+```{r eval = FALSE}
 session <- SeleniumSession$new(host = "172.17.0.1", port = 4444)
 ```
 
@@ -76,7 +77,7 @@ If you are using Chrome, and you see a browser open, but the call to
 `SeleniumSession$new()` times out, you may need to use a different debugging port.
 For example:
 
-```r
+```{r eval = FALSE}
 session <- SeleniumSession$new(
   browser = "chrome",
   capabilities = list(
@@ -102,7 +103,7 @@ For example:
 ### Stale element reference errors
 At some point, when using selenium, you will encounter the following error:
 
-```r
+```{r eval = FALSE}
 #> Error in `element$click()`:
 #> ! Stale element reference.
 #> ✖ The element with the reference <...> is not known in the current browsing context
@@ -110,6 +111,7 @@ At some point, when using selenium, you will encounter the following error:
 #> ! HTTP 404 Not Found.
 #> Run `rlang::last_trace()` to see where the error occurred.
 ```
+
 This error is common when automating a website. Selenium is telling you that
 an element which you previously identified no longer exists. In all websites,
 especially complex ones, the DOM will be constantly updating itself, constantly


### PR DESCRIPTION
I'm not sure if this is needed anymore, and it has caveats (see #6).